### PR TITLE
refactor: update RoleClaimType to match the roles claim

### DIFF
--- a/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
@@ -113,7 +113,7 @@ public static class AuthenticationBuilderExtensions
     options.TokenValidationParameters = new TokenValidationParameters
     {
       NameClaimType = "name",
-      RoleClaimType = "role",
+      RoleClaimType = "roles",
       ValidateAudience = true,
       ValidAudience = logtoOptions.AppId,
       ValidateIssuer = true,


### PR DESCRIPTION
LogTo provides the user role under the roles claim, so we must change the RoleClaimType to match.

#https://github.com/logto-io/logto/issues/3411