### PR TITLE
[paused] feat: support organizations

### DIFF
--- a/src/Logto.AspNetCore.Authentication/LogtoOptions.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoOptions.cs
@@ -32,6 +32,8 @@ public class LogtoOptions
   /// <summary>
   /// The API resource that your application needs to access.
   /// See <a href="https://docs.logto.io/docs/recipes/rbac/">RBAC</a> to learn more about how to use role-based access control (RBAC) to protect API resources.
+  /// <br/>
+  /// If <see cref="LogtoParameters.Scopes.Organizations" /> is specified in <see cref="Scopes"/>, this value must not be set.
   /// </summary>
   public string? Resource { get; set; } = null;
   /// <summary>
@@ -63,6 +65,10 @@ public class LogtoOptions
   /// set this value to `true` since they are not included in the ID token.
   /// </summary>
   public bool GetClaimsFromUserInfoEndpoint { get; set; } = false;
+  /// <summary>
+  /// Get if `Scopes` contains `LogtoParameters.Scopes.Organizations`.
+  /// </summary>
+  public bool IsOrganizationsScopeRequested => Scopes.Contains(LogtoParameters.Scopes.Organizations);
 }
 
 /// <summary>

--- a/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
@@ -51,6 +51,18 @@ public static class LogtoParameters
     /// Note that when requesting this scope, you must set <see cref="LogtoOptions.GetClaimsFromUserInfoEndpoint"/> to <c>true</c>.
     /// </summary>
     public const string Identities = "identities";
+    /// <summary>
+    /// The scope for user's organization IDs and perform organization token grant per <see href="https://github.com/logto-io/rfcs">RFC 0001</see>.
+    /// <br/>
+    /// To learn more about Logto Organizations, see <see href="https://docs.logto.io/docs/recipes/organizations/" />.
+    /// </summary>
+    public const string Organizations = "urn:logto:scope:organizations";
+    /// <summary>
+    /// Scope for user's organization roles per <see href="https://github.com/logto-io/rfcs">RFC 0001</see>.
+    /// <br/>
+    /// To learn more about Logto Organizations, see <see href="https://docs.logto.io/docs/recipes/organizations/" />.
+    /// </summary>
+    public const string OrganizationRoles = "urn:logto:scope:organization_roles";
   }
 
   /// <summary>
@@ -114,5 +126,24 @@ public static class LogtoParameters
     /// The claim name for user's identities.
     /// </summary>
     public const string Identities = "identities";
+    /// <summary>
+    /// The claim name for user's organization IDs.
+    /// </summary>
+    public const string Organizations = "organizations";
+    /// <summary>
+    /// The claim name for user's organization roles. Each role is in the format of `<organization_id>:<role_name>`.
+    /// </summary>
+    public const string OrganizationRoles = "organization_roles";
+  }
+
+  /// <summary>
+  /// Resources that reserved by Logto, which cannot be defined by users.
+  /// </summary>
+  public static class ReservedResource
+  {
+    /// <summary>
+    /// The resource for organization template per <see href="https://github.com/logto-io/rfcs">RFC 0001</see>.
+    /// </summary>
+    public const string Organizations = "urn:logto:resource:organizations";
   }
 }

--- a/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
@@ -137,7 +137,13 @@ public static class AuthenticationBuilderExtensions
     }
 
     // Handle resource
-    if (!string.IsNullOrEmpty(logtoOptions.Resource))
+    if (logtoOptions.IsOrganizationsScopeRequested) {
+      if (!string.IsNullOrEmpty(logtoOptions.Resource)) {
+        throw new ArgumentException($"The {nameof(LogtoOptions.Resource)} must be null when requesting the {LogtoParameters.Scopes.Organizations} scope.");
+      }
+
+      options.Resource = LogtoParameters.ReservedResource.Organizations;
+    } else if (!string.IsNullOrEmpty(logtoOptions.Resource))
     {
       options.Resource = logtoOptions.Resource;
     }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
> **Note**
> since the current c# sdk heavily depends on `Microsoft.AspNetCore.Authentication.OpenIdConnect`, which uses the pattern that does not fit other SDKs and causes inconvenience on adding multiple resources and adopting organization tokens - pause the implementation until developer requests

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
