### PR TITLE
feat: allow configuring cookie domain

### DIFF
--- a/src/Logto.AspNetCore.Authentication/LogtoOptions.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoOptions.cs
@@ -63,6 +63,10 @@ public class LogtoOptions
   /// set this value to `true` since they are not included in the ID token.
   /// </summary>
   public bool GetClaimsFromUserInfoEndpoint { get; set; } = false;
+  /// <summary>
+  /// The domain to associate the cookie with. Allows multiple applications to share the cookie such as on sub-domains. 
+  /// </summary>
+  public string? CookieDomain { get; set; } = null;
 }
 
 /// <summary>

--- a/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
@@ -73,6 +73,7 @@ public static class AuthenticationBuilderExtensions
   {
     options.Cookie.Name = $"Logto.Cookie.{logtoOptions.AppId}";
     options.SlidingExpiration = true;
+    options.Cookie.Domain = logtoOptions.CookieDomain;
     options.Events = new CookieAuthenticationEvents
     {
       OnValidatePrincipal = context => new LogtoCookieContextManager(authenticationScheme, context).Handle()


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

this is a cherry-pick pr of #9 with signed commit

To enable cookies to be shared by .NET applications on sub-domains of the same domains the CookieDomain field has been added to the LogToOptions and assigned to the cookie in ConfigureCookieOptions. By default it is null.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
/
