### PR TITLE
Fix: LogtoCookieContextManager setting double slash in fetch token request uri

### DIFF
--- a/src/Logto.AspNetCore.Authentication.Tests/LogtoCookieContextManagerTests.cs
+++ b/src/Logto.AspNetCore.Authentication.Tests/LogtoCookieContextManagerTests.cs
@@ -1,0 +1,13 @@
+﻿namespace Logto.AspNetCore.Authentication.Tests;
+
+public class LogtoCookieContextManagerTests
+{
+    [Theory]
+    [InlineData("https://www.example.com/", "https://www.example.com/oidc/token")]
+    [InlineData("https://www.example.com", "https://www.example.com/oidc/token")]
+    public void FetchTokenUriParseTest(string endpoint, string expectedUri)
+    {
+        var requestUri = LogtoCookieContextManager.GetTokenRequestUri(endpoint);
+        Assert.Equal(requestUri.ToString(), expectedUri);
+    }
+}

--- a/src/Logto.AspNetCore.Authentication.Tests/LogtoCookieContextManagerTests.cs
+++ b/src/Logto.AspNetCore.Authentication.Tests/LogtoCookieContextManagerTests.cs
@@ -5,9 +5,27 @@ public class LogtoCookieContextManagerTests
     [Theory]
     [InlineData("https://www.example.com/", "https://www.example.com/oidc/token")]
     [InlineData("https://www.example.com", "https://www.example.com/oidc/token")]
+    [InlineData("https://example.com", "https://example.com/oidc/token")]
+    [InlineData("http://www.example.com", "http://www.example.com/oidc/token")]
+    [InlineData("https://sub.example.com", "https://sub.example.com/oidc/token")]
+    [InlineData("https://www.example.com/path/", "https://www.example.com/path/oidc/token")]
     public void FetchTokenUriParseTest(string endpoint, string expectedUri)
     {
-        var requestUri = LogtoCookieContextManager.GetTokenRequestUri(endpoint);
+        var requestUri = LogtoCookieContextManager.GetOidcTokenRequestUri(endpoint);
         Assert.Equal(requestUri.ToString(), expectedUri);
     }
+
+    [Fact]
+    public void FetchTokenUriInvalidFormatTest()
+    {
+        Assert.Throws<UriFormatException>(() => LogtoCookieContextManager.GetOidcTokenRequestUri("https:///example.com//"));
+    }
+
+    [Fact]
+    public void FetchTokenUriNullOrEmptyTest()
+    {
+        Assert.Throws<ArgumentNullException>(() => LogtoCookieContextManager.GetOidcTokenRequestUri(null!));
+        Assert.Throws<UriFormatException>(() => LogtoCookieContextManager.GetOidcTokenRequestUri(string.Empty));
+    }
+
 }

--- a/src/Logto.AspNetCore.Authentication/LogtoCookieContextManager.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoCookieContextManager.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -78,7 +79,6 @@ public class LogtoCookieContextManager
     if (logtoOptions.Resource != null && !await RefreshTokens(true))
     {
       context.RejectPrincipal();
-      return;
     }
   }
 
@@ -177,7 +177,7 @@ public class LogtoCookieContextManager
     }
 
     // TODO: The token endpoint should be read from the discovery endpoint or the OpenID Connect context.
-    var request = new HttpRequestMessage(HttpMethod.Post, $"{logtoOptions.Endpoint}/oidc/token")
+    var request = new HttpRequestMessage(HttpMethod.Post, GetTokenRequestUri(logtoOptions.Endpoint))
     {
       Content = new FormUrlEncodedContent(body)
     };
@@ -190,5 +190,12 @@ public class LogtoCookieContextManager
     {
       PropertyNameCaseInsensitive = true,
     })!;
+  }
+
+  public static Uri GetTokenRequestUri(string endpoint)
+  {
+    var baseUri = new Uri(endpoint);
+    var requestUri = new Uri(baseUri, "/oidc/token");
+    return requestUri;
   }
 }

--- a/src/Logto.AspNetCore.Authentication/LogtoCookieContextManager.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoCookieContextManager.cs
@@ -177,7 +177,7 @@ public class LogtoCookieContextManager
     }
 
     // TODO: The token endpoint should be read from the discovery endpoint or the OpenID Connect context.
-    var request = new HttpRequestMessage(HttpMethod.Post, GetTokenRequestUri(logtoOptions.Endpoint))
+    var request = new HttpRequestMessage(HttpMethod.Post, GetOidcTokenRequestUri(logtoOptions.Endpoint))
     {
       Content = new FormUrlEncodedContent(body)
     };
@@ -192,10 +192,16 @@ public class LogtoCookieContextManager
     })!;
   }
 
-  public static Uri GetTokenRequestUri(string endpoint)
+  /// <summary>
+  /// Constructs a URI for the OpenID Connect (OIDC) token request based on the provided endpoint.
+  /// </summary>
+  /// <param name="endpoint">The base endpoint URL as a string.</param>
+  /// <returns>A <see cref="Uri"/> object representing the full token request URI.</returns>
+  /// <exception cref="UriFormatException">Thrown when the provided endpoint is not a valid URI.</exception>
+  public static Uri GetOidcTokenRequestUri(string endpoint)
   {
     var baseUri = new Uri(endpoint);
-    var requestUri = new Uri(baseUri, "/oidc/token");
+    var requestUri = new Uri(baseUri, "oidc/token");
     return requestUri;
   }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This pull request closes #29 . The problem was the following code:
```csharp
var request = new HttpRequestMessage(HttpMethod.Post, $"{logtoOptions.Endpoint}/oidc/token")
{
   Content = new FormUrlEncodedContent(body)
};
```
has added a double slash after the endpoint, because the endpoint already ended with a slash which resulted in a 404 Not found rejecting the cookie.
I have refactored this and added a new method GetOidcTokenRequestUri to the LogtoCookieContextManager that will safely add "oidc/token" to the endpoint. I also added some test cases to test this method.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
I added a new test file with test cases that test the GetOidcTokenRequestUri method.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [X] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
