### PR TITLE
feat: support identifiers, first_screen, direct_sign_in and extra_params sign-in params

### DIFF
--- a/samples/sample-blazor/Program.cs
+++ b/samples/sample-blazor/Program.cs
@@ -52,9 +52,11 @@ app.MapGet("/SignIn", async context =>
             RedirectUri = "/" 
         };
 
-        // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
+        /// <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen"/>
+        /// <see cref="LogtoParameters.Authentication.FirstScreen"/>
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
-        // Set the `identifiers`, this parameter MUST be used together with `first_screen`.
+        
+        // This parameter MUST be used together with `first_screen`.
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
         {
             LogtoParameters.Authentication.Identifiers.Username,
@@ -65,7 +67,9 @@ app.MapGet("/SignIn", async context =>
             Target = "github",
             Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
         };
-        // Set the direct sign-in, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in.
+        
+        /// <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in"/>
+        /// <see cref="LogtoParameters.Authentication.DirectSignIn"/>
         authProperties.SetParameter("direct_sign_in", System.Text.Json.JsonSerializer.Serialize(directSignIn));
 
         await context.ChallengeAsync(authProperties);

--- a/samples/sample-blazor/Program.cs
+++ b/samples/sample-blazor/Program.cs
@@ -58,6 +58,22 @@ app.MapGet("/SignIn", async context =>
             LogtoParameters.Authentication.Identifiers.Username,
         }));
 
+        // Set `direct_sign_in`
+        var directSignIn = new LogtoParameters.Authentication.DirectSignIn
+        {
+            Target = "github",
+            Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
+        };
+        authProperties.SetParameter("direct_sign_in", System.Text.Json.JsonSerializer.Serialize(directSignIn));
+
+        // Set `extra_params`
+        var extraParams = new LogtoParameters.Authentication.ExtraParams
+        {
+            { "utm_source", "website" },
+            { "utm_medium", "organic" }
+        };
+        authProperties.SetParameter("extra_params", System.Text.Json.JsonSerializer.Serialize(extraParams));
+
         await context.ChallengeAsync(authProperties);
     } 
     else 

--- a/samples/sample-blazor/Program.cs
+++ b/samples/sample-blazor/Program.cs
@@ -54,7 +54,7 @@ app.MapGet("/SignIn", async context =>
 
         // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
-        // Set the identifiers, should work with `first_screen`.
+        // Set the `identifiers`, this parameter MUST be used together with `first_screen`.
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
         {
             LogtoParameters.Authentication.Identifiers.Username,

--- a/samples/sample-blazor/Program.cs
+++ b/samples/sample-blazor/Program.cs
@@ -52,27 +52,21 @@ app.MapGet("/SignIn", async context =>
             RedirectUri = "/" 
         };
 
+        // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
+        // Set the identifiers, should work with `first_screen`.
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
-        { 
+        {
             LogtoParameters.Authentication.Identifiers.Username,
         }));
 
-        // Set `direct_sign_in`
         var directSignIn = new LogtoParameters.Authentication.DirectSignIn
         {
             Target = "github",
             Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
         };
+        // Set the direct sign-in, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in.
         authProperties.SetParameter("direct_sign_in", System.Text.Json.JsonSerializer.Serialize(directSignIn));
-
-        // Set `extra_params`
-        var extraParams = new LogtoParameters.Authentication.ExtraParams
-        {
-            { "utm_source", "website" },
-            { "utm_medium", "organic" }
-        };
-        authProperties.SetParameter("extra_params", System.Text.Json.JsonSerializer.Serialize(extraParams));
 
         await context.ChallengeAsync(authProperties);
     } 

--- a/samples/sample-blazor/Program.cs
+++ b/samples/sample-blazor/Program.cs
@@ -47,8 +47,21 @@ app.MapGet("/SignIn", async context =>
 {
     if (!(context.User?.Identity?.IsAuthenticated ?? false))
     {
-        await context.ChallengeAsync(new AuthenticationProperties { RedirectUri = "/" });
-    } else {
+        var authProperties = new AuthenticationProperties 
+        { 
+            RedirectUri = "/" 
+        };
+
+        authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
+        authProperties.SetParameter("identifiers", string.Join(",", new[] 
+        { 
+            LogtoParameters.Authentication.Identifiers.Username,
+        }));
+
+        await context.ChallengeAsync(authProperties);
+    } 
+    else 
+    {
         context.Response.Redirect("/");
     }
 });

--- a/samples/sample-mvc/Controllers/HomeController.cs
+++ b/samples/sample-mvc/Controllers/HomeController.cs
@@ -33,7 +33,7 @@ public class HomeController : Controller
 
         // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
-        // Set the identifiers, should work with `first_screen`.
+        // Set the `identifiers`, this parameter MUST be used together with `first_screen`.
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
         { 
             LogtoParameters.Authentication.Identifiers.Username,

--- a/samples/sample-mvc/Controllers/HomeController.cs
+++ b/samples/sample-mvc/Controllers/HomeController.cs
@@ -31,7 +31,9 @@ public class HomeController : Controller
             RedirectUri = "/" 
         };
 
+        // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
+        // Set the identifiers, should work with `first_screen`.
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
         { 
             LogtoParameters.Authentication.Identifiers.Username,
@@ -42,14 +44,8 @@ public class HomeController : Controller
             Target = "github",
             Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
         };
+        // Set the direct sign-in, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in.
         authProperties.SetParameter("direct_sign_in", JsonSerializer.Serialize(directSignIn));
-
-        var extraParams = new LogtoParameters.Authentication.ExtraParams
-        {
-            { "utm_source", "website" },
-            { "utm_medium", "organic" }
-        };
-        authProperties.SetParameter("extra_params", JsonSerializer.Serialize(extraParams));
 
         return Challenge(authProperties);
     }

--- a/samples/sample-mvc/Controllers/HomeController.cs
+++ b/samples/sample-mvc/Controllers/HomeController.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using sample_mvc.Models;
+using System.Text.Json;
 
 namespace sample_mvc.Controllers;
 
@@ -30,11 +31,25 @@ public class HomeController : Controller
             RedirectUri = "/" 
         };
 
-        authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.SignIn);
+        authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
         { 
             LogtoParameters.Authentication.Identifiers.Username,
         }));
+
+        var directSignIn = new LogtoParameters.Authentication.DirectSignIn
+        {
+            Target = "github",
+            Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
+        };
+        authProperties.SetParameter("direct_sign_in", JsonSerializer.Serialize(directSignIn));
+
+        var extraParams = new LogtoParameters.Authentication.ExtraParams
+        {
+            { "utm_source", "website" },
+            { "utm_medium", "organic" }
+        };
+        authProperties.SetParameter("extra_params", JsonSerializer.Serialize(extraParams));
 
         return Challenge(authProperties);
     }

--- a/samples/sample-mvc/Controllers/HomeController.cs
+++ b/samples/sample-mvc/Controllers/HomeController.cs
@@ -25,7 +25,18 @@ public class HomeController : Controller
 
     public IActionResult SignIn()
     {
-        return Challenge(new AuthenticationProperties { RedirectUri = "/" });
+        var authProperties = new AuthenticationProperties 
+        { 
+            RedirectUri = "/" 
+        };
+
+        authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.SignIn);
+        authProperties.SetParameter("identifiers", string.Join(",", new[] 
+        { 
+            LogtoParameters.Authentication.Identifiers.Username,
+        }));
+
+        return Challenge(authProperties);
     }
 
     // Use the `new` keyword to avoid conflict with the `ControllerBase.SignOut` method

--- a/samples/sample-mvc/Controllers/HomeController.cs
+++ b/samples/sample-mvc/Controllers/HomeController.cs
@@ -31,11 +31,13 @@ public class HomeController : Controller
             RedirectUri = "/" 
         };
 
-        // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
+        /// <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen"/>
+        /// <see cref="LogtoParameters.Authentication.FirstScreen"/>
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
-        // Set the `identifiers`, this parameter MUST be used together with `first_screen`.
+        
+        // This parameter MUST be used together with `first_screen`.
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
-        { 
+        {
             LogtoParameters.Authentication.Identifiers.Username,
         }));
 
@@ -44,7 +46,9 @@ public class HomeController : Controller
             Target = "github",
             Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
         };
-        // Set the direct sign-in, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in.
+
+        /// <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in"/>
+        /// <see cref="LogtoParameters.Authentication.DirectSignIn"/>
         authProperties.SetParameter("direct_sign_in", JsonSerializer.Serialize(directSignIn));
 
         return Challenge(authProperties);

--- a/samples/sample/Pages/Index.cshtml.cs
+++ b/samples/sample/Pages/Index.cshtml.cs
@@ -30,7 +30,7 @@ public class IndexModel : PageModel
 
         // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
-        // Set the identifiers, should work with `first_screen`.
+        // Set the `identifiers`, this parameter MUST be used together with `first_screen`.
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
         { 
             LogtoParameters.Authentication.Identifiers.Username,

--- a/samples/sample/Pages/Index.cshtml.cs
+++ b/samples/sample/Pages/Index.cshtml.cs
@@ -22,7 +22,18 @@ public class IndexModel : PageModel
 
     public async Task OnPostSignInAsync()
     {
-        await HttpContext.ChallengeAsync(new AuthenticationProperties { RedirectUri = "/" });
+        var authProperties = new AuthenticationProperties 
+        { 
+            RedirectUri = "/" 
+        };
+
+        authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
+        authProperties.SetParameter("identifiers", string.Join(",", new[] 
+        { 
+            LogtoParameters.Authentication.Identifiers.Username,
+        }));
+
+        await HttpContext.ChallengeAsync(authProperties);
     }
 
     public async Task OnPostSignOutAsync()

--- a/samples/sample/Pages/Index.cshtml.cs
+++ b/samples/sample/Pages/Index.cshtml.cs
@@ -28,11 +28,13 @@ public class IndexModel : PageModel
             RedirectUri = "/" 
         };
 
-        // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
+        /// <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen"/>
+        /// <see cref="LogtoParameters.Authentication.FirstScreen"/>
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
-        // Set the `identifiers`, this parameter MUST be used together with `first_screen`.
+        
+        // This parameter MUST be used together with `first_screen`
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
-        { 
+        {
             LogtoParameters.Authentication.Identifiers.Username,
         }));
 
@@ -41,7 +43,9 @@ public class IndexModel : PageModel
             Target = "github",
             Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
         };
-        // Set the direct sign-in, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in.
+        
+        /// <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in"/>
+        /// <see cref="LogtoParameters.Authentication.DirectSignIn"/>
         authProperties.SetParameter("direct_sign_in", JsonSerializer.Serialize(directSignIn));
 
         await HttpContext.ChallengeAsync(authProperties);

--- a/samples/sample/Pages/Index.cshtml.cs
+++ b/samples/sample/Pages/Index.cshtml.cs
@@ -1,6 +1,7 @@
 ﻿using Logto.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Text.Json;
 
 namespace sample.Pages;
 
@@ -32,6 +33,20 @@ public class IndexModel : PageModel
         { 
             LogtoParameters.Authentication.Identifiers.Username,
         }));
+
+        var directSignIn = new LogtoParameters.Authentication.DirectSignIn
+        {
+            Target = "github",
+            Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
+        };
+        authProperties.SetParameter("direct_sign_in", JsonSerializer.Serialize(directSignIn));
+
+        var extraParams = new LogtoParameters.Authentication.ExtraParams
+        {
+            { "utm_source", "website" },
+            { "utm_medium", "organic" }
+        };
+        authProperties.SetParameter("extra_params", JsonSerializer.Serialize(extraParams));
 
         await HttpContext.ChallengeAsync(authProperties);
     }

--- a/samples/sample/Pages/Index.cshtml.cs
+++ b/samples/sample/Pages/Index.cshtml.cs
@@ -28,7 +28,9 @@ public class IndexModel : PageModel
             RedirectUri = "/" 
         };
 
+        // Set the first screen, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen.
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
+        // Set the identifiers, should work with `first_screen`.
         authProperties.SetParameter("identifiers", string.Join(",", new[] 
         { 
             LogtoParameters.Authentication.Identifiers.Username,
@@ -39,14 +41,8 @@ public class IndexModel : PageModel
             Target = "github",
             Method = LogtoParameters.Authentication.DirectSignIn.Methods.Social
         };
+        // Set the direct sign-in, see https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in.
         authProperties.SetParameter("direct_sign_in", JsonSerializer.Serialize(directSignIn));
-
-        var extraParams = new LogtoParameters.Authentication.ExtraParams
-        {
-            { "utm_source", "website" },
-            { "utm_medium", "organic" }
-        };
-        authProperties.SetParameter("extra_params", JsonSerializer.Serialize(extraParams));
 
         await HttpContext.ChallengeAsync(authProperties);
     }

--- a/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
@@ -150,7 +150,7 @@ public static class LogtoParameters
 
     /// <summary>
     /// The identifiers to use for authentication.
-    /// Should work with <see cref="FirstScreen"/>.
+    /// This parameter MUST be used together with <see cref="FirstScreen"/>.
     /// </summary>
     public static class Identifiers
     {

--- a/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
@@ -1,4 +1,5 @@
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Collections.Generic;
 
 namespace Logto.AspNetCore.Authentication;
 
@@ -166,6 +167,42 @@ public static class LogtoParameters
       /// Use username for authentication.
       /// </summary>
       public const string Username = "username";
+    }
+
+    /// <summary>
+    /// Direct sign-in configuration.
+    /// </summary>
+    public class DirectSignIn
+    {
+      /// <summary>
+      /// The target identifier for direct sign-in.
+      /// </summary>
+      public string Target { get; set; } = string.Empty;
+
+      /// <summary>
+      /// The sign-in method.
+      /// </summary>
+      public string Method { get; set; } = string.Empty;
+
+      public static class Methods
+      {
+        /// <summary>
+        /// Single sign-on method.
+        /// </summary>
+        public const string Sso = "sso";
+
+        /// <summary>
+        /// Social sign-in method.
+        /// </summary>
+        public const string Social = "social";
+      }
+    }
+
+    /// <summary>
+    /// Extra parameters to be passed to the authorization endpoint.
+    /// </summary>
+    public class ExtraParams : Dictionary<string, string>
+    {
     }
   }
 }

--- a/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
@@ -115,4 +115,57 @@ public static class LogtoParameters
     /// </summary>
     public const string Identities = "identities";
   }
+
+  /// <summary>
+  /// The authentication parameters for Logto sign-in experience customization.
+  /// </summary>
+  public static class Authentication
+  {
+    /// <summary>
+    /// The first screen to show in the sign-in experience.
+    /// </summary>
+    public static class FirstScreen
+    {
+      /// <summary>
+      /// Show the register form first.
+      /// </summary>
+      public const string Register = "identifier:register";
+
+      /// <summary>
+      /// Show the sign-in form first.
+      /// </summary>
+      public const string SignIn = "identifier:sign_in";
+
+      /// <summary>
+      /// Show the single sign-on form first.
+      /// </summary>
+      public const string SingleSignOn = "single_sign_on";
+
+      /// <summary>
+      /// Show the reset password form first.
+      /// </summary>
+      public const string ResetPassword = "reset_password";
+    }
+
+    /// <summary>
+    /// The identifiers to use for authentication.
+    /// </summary>
+    public static class Identifiers
+    {
+      /// <summary>
+      /// Use email for authentication.
+      /// </summary>
+      public const string Email = "email";
+      
+      /// <summary>
+      /// Use phone for authentication.
+      /// </summary>
+      public const string Phone = "phone";
+      
+      /// <summary>
+      /// Use username for authentication.
+      /// </summary>
+      public const string Username = "username";
+    }
+  }
 }

--- a/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
@@ -150,6 +150,7 @@ public static class LogtoParameters
 
     /// <summary>
     /// The identifiers to use for authentication.
+    /// Should work with <see cref="FirstScreen"/>.
     /// </summary>
     public static class Identifiers
     {

--- a/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
+++ b/src/Logto.AspNetCore.Authentication/LogtoParameters.cs
@@ -124,6 +124,7 @@ public static class LogtoParameters
   {
     /// <summary>
     /// The first screen to show in the sign-in experience.
+    /// See <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen"/> for more details.
     /// </summary>
     public static class FirstScreen
     {
@@ -172,6 +173,7 @@ public static class LogtoParameters
 
     /// <summary>
     /// Direct sign-in configuration.
+    /// See <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in"/> for more details.
     /// </summary>
     public class DirectSignIn
     {

--- a/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
@@ -143,10 +143,13 @@ public static class AuthenticationBuilderExtensions
       },
       OnRedirectToIdentityProviderForSignOut = async context =>
       {
+        // Clean up the cookie when signing out.
         await context.HttpContext.SignOutAsync(cookieScheme);
+        
+        // Rebuild parameters since we use <c>client_id</c> for sign-out, no need to use <c>id_token_hint</c>.
         context.ProtocolMessage.Parameters.Remove(OpenIdConnectParameterNames.IdTokenHint);
         context.ProtocolMessage.Parameters.Add(OpenIdConnectParameterNames.ClientId, logtoOptions.AppId);
-      }
+      },
     };
     options.TokenValidationParameters = new TokenValidationParameters
     {

--- a/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
@@ -114,6 +114,31 @@ public static class AuthenticationBuilderExtensions
           context.ProtocolMessage.Parameters.Add("identifiers", identifiers?.ToString());
         }
 
+        if (context.Properties.Parameters.TryGetValue("direct_sign_in", out var directSignIn))
+        {
+          var directSignInOption = System.Text.Json.JsonSerializer.Deserialize<LogtoParameters.Authentication.DirectSignIn>(
+            directSignIn?.ToString() ?? "{}"
+          );
+          if (directSignInOption != null && !string.IsNullOrEmpty(directSignInOption.Method) && !string.IsNullOrEmpty(directSignInOption.Target))
+          {
+            context.ProtocolMessage.Parameters.Add("direct_sign_in", $"{directSignInOption.Method}:{directSignInOption.Target}");
+          }
+        }
+
+        if (context.Properties.Parameters.TryGetValue("extra_params", out var extraParams))
+        {
+          var parameters = System.Text.Json.JsonSerializer.Deserialize<LogtoParameters.Authentication.ExtraParams>(
+            extraParams?.ToString() ?? "{}"
+          );
+          if (parameters != null)
+          {
+            foreach (var param in parameters)
+            {
+              context.ProtocolMessage.Parameters.Add(param.Key, param.Value);
+            }
+          }
+        }
+
         return Task.CompletedTask;
       },
       OnRedirectToIdentityProviderForSignOut = async context =>

--- a/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
@@ -145,7 +145,6 @@ public static class AuthenticationBuilderExtensions
       {
         // Clean up the cookie when signing out.
         await context.HttpContext.SignOutAsync(cookieScheme);
-        
         // Rebuild parameters since we use <c>client_id</c> for sign-out, no need to use <c>id_token_hint</c>.
         context.ProtocolMessage.Parameters.Remove(OpenIdConnectParameterNames.IdTokenHint);
         context.ProtocolMessage.Parameters.Add(OpenIdConnectParameterNames.ClientId, logtoOptions.AppId);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add following sign-in params support:
1. `first_screen`: This parameter allows you to customize the first screen that users see when they start the authentication process, see [reference](https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in).
2. `identifiers`: should work with `first_screen`
3. `direct_sign_in`: This parameter allows you to skip the first screen and invoke the sign-in process directly, see [reference](https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#direct-sign-in).
4. `extra_params`: provides the ability of taking any other extra params

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
