### PR TITLE
fix: fix sign-in parameter `identifier`

### DIFF
--- a/samples/sample-blazor/Program.cs
+++ b/samples/sample-blazor/Program.cs
@@ -54,12 +54,12 @@ app.MapGet("/SignIn", async context =>
 
         /// <see href="https://docs.logto.io/docs/references/openid-connect/authentication-parameters/#first-screen"/>
         /// <see cref="LogtoParameters.Authentication.FirstScreen"/>
-        authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
+        authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.SignIn);
         
-        // This parameter MUST be used together with `first_screen`.
-        authProperties.SetParameter("identifiers", string.Join(",", new[] 
+        authProperties.SetParameter("identifiers", System.Text.Json.JsonSerializer.Serialize(new[] 
         {
             LogtoParameters.Authentication.Identifiers.Username,
+            LogtoParameters.Authentication.Identifiers.Email,
         }));
 
         var directSignIn = new LogtoParameters.Authentication.DirectSignIn

--- a/samples/sample-mvc/Controllers/HomeController.cs
+++ b/samples/sample-mvc/Controllers/HomeController.cs
@@ -35,8 +35,7 @@ public class HomeController : Controller
         /// <see cref="LogtoParameters.Authentication.FirstScreen"/>
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
         
-        // This parameter MUST be used together with `first_screen`.
-        authProperties.SetParameter("identifiers", string.Join(",", new[] 
+        authProperties.SetParameter("identifiers", JsonSerializer.Serialize(new[] 
         {
             LogtoParameters.Authentication.Identifiers.Username,
         }));

--- a/samples/sample/Pages/Index.cshtml.cs
+++ b/samples/sample/Pages/Index.cshtml.cs
@@ -32,8 +32,7 @@ public class IndexModel : PageModel
         /// <see cref="LogtoParameters.Authentication.FirstScreen"/>
         authProperties.SetParameter("first_screen", LogtoParameters.Authentication.FirstScreen.Register);
         
-        // This parameter MUST be used together with `first_screen`
-        authProperties.SetParameter("identifiers", string.Join(",", new[] 
+        authProperties.SetParameter("identifiers", JsonSerializer.Serialize(new[] 
         {
             LogtoParameters.Authentication.Identifiers.Username,
         }));

--- a/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
+++ b/src/Logto.AspNetCore.Authentication/extensions/AuthenticationBuilderExtensions.cs
@@ -111,7 +111,13 @@ public static class AuthenticationBuilderExtensions
 
         if (context.Properties.Parameters.TryGetValue("identifiers", out var identifiers))
         {
-          context.ProtocolMessage.Parameters.Add("identifiers", identifiers?.ToString());
+          var identifierArray = System.Text.Json.JsonSerializer.Deserialize<string[]>(
+            identifiers?.ToString() ?? "[]"
+          );
+          if (identifierArray?.Length > 0)
+          {
+            context.ProtocolMessage.Parameters.Add("identifier", string.Join(" ", identifierArray));
+          }
         }
 
         if (context.Properties.Parameters.TryGetValue("direct_sign_in", out var directSignIn))


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. Sign-in URL query parameter should be "identifier" not "identifiers"
2. sign-in parameter "identifiers" should be serialized string array

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
